### PR TITLE
feat: hydrate OriginalRequest in GraphqlRequest type [NERDS-862]

### DIFF
--- a/request/parse.go
+++ b/request/parse.go
@@ -27,6 +27,8 @@ func Parse(r *http.Request) (*GraphqlRequest, error) {
 			return nil, err
 		}
 	}
+	clonedRequest := r.Clone(r.Context())
+	req.OriginalRequest = clonedRequest
 
 	return &req, nil
 }

--- a/request/parse_test.go
+++ b/request/parse_test.go
@@ -41,4 +41,12 @@ func TestParse(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, "GetUser", r.OperationName)
 	})
+	t.Run("hydrates valid request", func(t *testing.T) {
+		req, err := http.NewRequest("POST", "/", strings.NewReader(fmt.Sprintf(`{"query": "%s", "variables": %s}`, graphqlOperationWithFragment, graphqlOperationVariables)))
+		req.Header.Set("x-user-id", "123")
+		assert.NoError(t, err)
+		r, err := request.Parse(req)
+		assert.NoError(t, err)
+		assert.Equal(t, "123", r.OriginalRequest.Header.Get("x-user-id"))
+	})
 }


### PR DESCRIPTION
## Pull Request Submission Checklist

Please confirm that you have done the following before requesting reviews:

- [x] I have confirmed that the PR type is appropriate for the change I am making according to the [Honest Pull Request and Commit Message Naming Conventions](https://www.notion.so/honestbank/Pull-Request-and-Commit-Message-Naming-Conventions-bd97f2cbb34c4c73b1ff3a3e384b850c).
- [x] I have typed an adequate description that explains **why** I am making this change.
- [x] I have installed and run standard pre-commit hooks that lints and validates my code.

### Description

* As of now, there's no way to assert on header value because OriginalRequest is always nil
* This PR adds clones the request (without body) and adds it to OriginalRequest parameter

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/honestbank/hijack/8)
<!-- Reviewable:end -->
