### PR TITLE
feat: add a Sequencer to return data based on number of calls [NERDS-862]

### DIFF
--- a/response_sequence.go
+++ b/response_sequence.go
@@ -1,0 +1,26 @@
+package hijack
+
+type seq[T any] struct {
+	sequence []T
+	index    int
+}
+
+type Response struct {
+	Data  string
+	Error error
+}
+
+func (s *seq[T]) GetNext() T {
+	defer func() { s.index = s.index + 1 }()
+	return s.sequence[s.index]
+}
+
+func Sequence[T any](items ...T) Sequencer[T] {
+	return &seq[T]{
+		sequence: items,
+	}
+}
+
+type Sequencer[T any] interface {
+	GetNext() T
+}

--- a/response_sequence_test.go
+++ b/response_sequence_test.go
@@ -1,0 +1,31 @@
+package hijack_test
+
+import (
+	"testing"
+
+	"github.com/honestbank/hijack/v2"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSequence(t *testing.T) {
+	t.Run("can return sequence of items", func(t *testing.T) {
+		seq := hijack.Sequence(1, 2, 3, 4, 5)
+		assert.Equal(t, 1, seq.GetNext())
+		assert.Equal(t, 2, seq.GetNext())
+		assert.Equal(t, 3, seq.GetNext())
+		assert.Equal(t, 4, seq.GetNext())
+		assert.Equal(t, 5, seq.GetNext())
+	})
+	t.Run("panics when it runs out of items in the sequence", func(t *testing.T) {
+		seq := hijack.Sequence(1, 2, 3, 4, 5)
+		assert.NotPanics(t, func() { seq.GetNext() })
+		assert.NotPanics(t, func() { seq.GetNext() })
+		assert.NotPanics(t, func() { seq.GetNext() })
+		assert.NotPanics(t, func() { seq.GetNext() })
+		assert.NotPanics(t, func() { seq.GetNext() })
+		assert.Panics(t, func() {
+			seq.GetNext()
+		})
+	})
+}


### PR DESCRIPTION
## Pull Request Submission Checklist

Please confirm that you have done the following before requesting reviews:

- [x] I have confirmed that the PR type is appropriate for the change I am making according to the [Honest Pull Request and Commit Message Naming Conventions](https://www.notion.so/honestbank/Pull-Request-and-Commit-Message-Naming-Conventions-bd97f2cbb34c4c73b1ff3a3e384b850c).
- [x] I have typed an adequate description that explains **why** I am making this change.
- [x] I have installed and run standard pre-commit hooks that lints and validates my code.

### Description

* Currently, if a operation is called multiple times, the only way to return multiple types of data is using a counter.
* This adds a Sequencer interface and implementation which can let you return different data sequentially

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/honestbank/hijack/9)
<!-- Reviewable:end -->
