### PR TITLE
fix: panic when handler is not found

### DIFF
--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -19,7 +19,7 @@ func (h *handlers) Set(operationName string, item func(r *request.GraphqlRequest
 func (h *handlers) Handle(r *request.GraphqlRequest) (string, error) {
 	handler := h.items[r.OperationName]
 	if handler == nil {
-		return "", panic("no handler found for %s", r.OperationName)
+		return "", panic(fmt.Sprintf("no handler found for %s", r.OperationName))
 	}
 
 	return handler(r)

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -19,7 +19,7 @@ func (h *handlers) Set(operationName string, item func(r *request.GraphqlRequest
 func (h *handlers) Handle(r *request.GraphqlRequest) (string, error) {
 	handler := h.items[r.OperationName]
 	if handler == nil {
-		return "", fmt.Errorf("no handler found for %s", r.OperationName)
+		return "", panic("no handler found for %s", r.OperationName)
 	}
 
 	return handler(r)

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -19,7 +19,7 @@ func (h *handlers) Set(operationName string, item func(r *request.GraphqlRequest
 func (h *handlers) Handle(r *request.GraphqlRequest) (string, error) {
 	handler := h.items[r.OperationName]
 	if handler == nil {
-		return "", panic(fmt.Sprintf("no handler found for %s", r.OperationName))
+		panic(fmt.Sprintf("no handler found for %s", r.OperationName))
 	}
 
 	return handler(r)

--- a/handlers/handlers_test.go
+++ b/handlers/handlers_test.go
@@ -39,6 +39,6 @@ func TestNew(t *testing.T) {
 
 	req.OperationName = "5"
 	assert.Panics(t, func() {
-		_, _ := h.Handle(&req)
+		_, _ = h.Handle(&req)
 	})
 }

--- a/handlers/handlers_test.go
+++ b/handlers/handlers_test.go
@@ -38,7 +38,7 @@ func TestNew(t *testing.T) {
 	assert.Equal(t, "4", res)
 
 	req.OperationName = "5"
-	res, err := h.Handle(&req)
-	assert.Equal(t, "", res)
-	assert.EqualError(t, err, "no handler found for 5")
+	assert.Panics(t, func() {
+		_, _ := h.Handle(&req)
+	})
 }


### PR DESCRIPTION
## Pull Request Submission Checklist

Please confirm that you have done the following before requesting reviews:

- [x] I have confirmed that the PR type is appropriate for the change I am making according to the [Honest Pull Request and Commit Message Naming Conventions](https://www.notion.so/honestbank/Pull-Request-and-Commit-Message-Naming-Conventions-bd97f2cbb34c4c73b1ff3a3e384b850c).
- [x] I have typed an adequate description that explains **why** I am making this change.
- [x] I have installed and run standard pre-commit hooks that lints and validates my code.

### Description

* we've found that when returning error instead of panicking when handler is not found, we might sometimes assert that there's an error, but not specifically what type of errors.
* Additionally, it's better to panic to make this very explicit and find issues early in tests.
* This PR changes hijack behavior to panic instead of returning an error that can be confused to network errors or graphql errors

While it does *look* like a breaking change, it doesn't change signature, and if it actually does panic in some tests, it means the tests showed a false positive, and they should be updated to check for proper error.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/honestbank/hijack/10)
<!-- Reviewable:end -->
